### PR TITLE
Added possibility of specyfying vector size

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Then we do the Word2Vec step through [Word2Vec.jl](https://github.com/JuliaText/
 model = learn_embeddings(walks)
 vectors = model.vectors
 ```
+You can specify embedding vector length with `size` keyword argument in the `learn_embeddings` function.
 
 In order to plot the embedded network we need to perform a dimensionality reduction (working on the parameters)
 

--- a/src/rw.jl
+++ b/src/rw.jl
@@ -117,7 +117,7 @@ function alias_draw(J,q)
     end
 end
 
-function learn_embeddings(walks)
+function learn_embeddings(walks;size::Int=100)
     str_walks=map(x -> string.(x),walks)
     if Sys.iswindows()
         rpath = pwd()
@@ -128,7 +128,7 @@ function learn_embeddings(walks)
     the_vecs = joinpath(rpath,"str_walk-vec.txt")
 
     writedlm(the_walks,str_walks)
-    word2vec(the_walks,the_vecs,verbose=true)
+    word2vec(the_walks,the_vecs,verbose=true,size=size)
     model=wordvectors(the_vecs)
     model
 end


### PR DESCRIPTION
Added the keyword argument `size` to the `learn_embeddings` function, which is then passed as the `size` keyword argument to the `word2vec` function, which will enable specyfying different embedding vectors length.
The default value of the argument is the same as the default value in `word2vec` function, so it won't affect previous usage.